### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Should you have any questions regarding the provided sample code, please contact
 # Further Information
 
 Further Information on -- CAN itnerface -- can be found at the [Beckhoff Infosys](https://infosys.beckhof.com) under the [REPO TOPIC](https://infosys.beckhoff.com/content/1033/el6751/2519219467.html?id=682234135442548413)
+Additional resource official [Beckhoff CAN Interface Documentation](https://download.beckhoff.com/download/document/io/infrastructure-components/can-interface_en.pdf).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Should you have any questions regarding the provided sample code, please contact
 
 # Further Information
 
-Further Information on -- CAN itnerface -- can be found at the [Beckhoff Infosys](https://infosys.beckhoff.com) under the [CAN Interface Topic](https://infosys.beckhoff.com/content/1033/el6751/2519219467.html?id=682234135442548413).
+Further Information on -- CAN interface -- can be found at the [Beckhoff Infosys](https://infosys.beckhoff.com) under the [CAN Interface Topic](https://infosys.beckhoff.com/content/1033/el6751/2519219467.html?id=682234135442548413).
 
 Additional resource official [Beckhoff CAN Interface Documentation](https://download.beckhoff.com/download/document/io/infrastructure-components/can-interface_en.pdf).
 

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ The following components must be installed to run sample code:
 - [TE1000 TwinCAT 3 Engineering](https://www.beckhoff.com/en-en/products/automation/twincat/te1xxx-twincat-3-engineering/te1000.html) version 3.1.4024.0 or higher
 - Beckhoff CANopen Master
 -- [EL6751](https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/el6xxx-communication/el6751.html)
+
+-- [CX2500-M510](https://www.beckhoff.com/en-ca/products/ipc/embedded-pcs/cx20x0-intel-celeron-core-i7/cx2500-m510.html)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Should you have any questions regarding the provided sample code, please contact
 
 # Further Information
 
-Further Information on -- CAN itnerface -- can be found at the [Beckhoff Infosys](https://infosys.beckhof.com) under the [REPO TOPIC](https://infosys.beckhoff.com/content/1033/el6751/2519219467.html?id=682234135442548413).
+Further Information on -- CAN itnerface -- can be found at the [Beckhoff Infosys](https://infosys.beckhoff.com) under the [REPO TOPIC](https://infosys.beckhoff.com/content/1033/el6751/2519219467.html?id=682234135442548413).
 
 Additional resource official [Beckhoff CAN Interface Documentation](https://download.beckhoff.com/download/document/io/infrastructure-components/can-interface_en.pdf).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Should you have any questions regarding the provided sample code, please contact
 
 # Further Information
 
-Further Information on -- CAN itnerface -- can be found at the [Beckhoff Infosys](https://infosys.beckhoff.com) under the [REPO TOPIC](https://infosys.beckhoff.com/content/1033/el6751/2519219467.html?id=682234135442548413).
+Further Information on -- CAN itnerface -- can be found at the [Beckhoff Infosys](https://infosys.beckhoff.com) under the [CAN Interface Topic](https://infosys.beckhoff.com/content/1033/el6751/2519219467.html?id=682234135442548413).
 
 Additional resource official [Beckhoff CAN Interface Documentation](https://download.beckhoff.com/download/document/io/infrastructure-components/can-interface_en.pdf).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Should you have any questions regarding the provided sample code, please contact
 
 # Further Information
 
-Further Information on -- CAN itnerface -- can be found at the [Beckhoff Infosys](https://infosys.beckhof.com) under the [REPO TOPIC](https://infosys.beckhoff.com/content/1033/el6751/2519219467.html?id=682234135442548413)
+Further Information on -- CAN itnerface -- can be found at the [Beckhoff Infosys](https://infosys.beckhof.com) under the [REPO TOPIC](https://infosys.beckhoff.com/content/1033/el6751/2519219467.html?id=682234135442548413).
+
 Additional resource official [Beckhoff CAN Interface Documentation](https://download.beckhoff.com/download/document/io/infrastructure-components/can-interface_en.pdf).
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Additional resource official [Beckhoff CAN Interface Documentation](https://down
 The following components must be installed to run sample code:
 
 - [TE1000 TwinCAT 3 Engineering](https://www.beckhoff.com/en-en/products/automation/twincat/te1xxx-twincat-3-engineering/te1000.html) version 3.1.4024.0 or higher
-- Beckhoff CANopen Master
--- [EL6751](https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/el6xxx-communication/el6751.html)
-
--- [CX2500-M510](https://www.beckhoff.com/en-ca/products/ipc/embedded-pcs/cx20x0-intel-celeron-core-i7/cx2500-m510.html)
+- One of the following Beckhoff CAN Master
+  - [EL6751](https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/el6xxx-communication/el6751.html)
+  - [CX2500-M510](https://www.beckhoff.com/en-ca/products/ipc/embedded-pcs/cx20x0-intel-celeron-core-i7/cx2500-m510.html)


### PR DESCRIPTION
Added reference to CX2500-M510 as compatible hardware.
Added reference to Official CAN Interface Manual from Beckhoff Main website.
Corrected Bullets.
Corrected Infosys URL.